### PR TITLE
feat: add an external backend services wakeup-signal emitter to the l…

### DIFF
--- a/src/api/services/data.ts
+++ b/src/api/services/data.ts
@@ -12,3 +12,12 @@ export async function getJobPostings(payload: JobPostingsRequestPayload) {
     payload
   );
 }
+
+/**
+ * Signal wake up to the testbed API
+ *
+ * @returns
+ */
+export async function wakeup() {
+  return axiosInstance.get(`${TESTBED_API_BASE_URL}/wake-up`);
+}

--- a/src/components/Login/Login.tsx
+++ b/src/components/Login/Login.tsx
@@ -1,5 +1,5 @@
-import { useState } from 'react';
 import { Button, Heading, Stack } from '@chakra-ui/react';
+import { useEffect, useState } from 'react';
 import { IoLogIn } from 'react-icons/io5';
 
 // types
@@ -28,6 +28,11 @@ const SuomiFiIcon = () => (
 
 export default function Login() {
   const [isLoading, setIsLoading] = useState<LoginType | null>(null);
+
+  // Send a wakeup signal to the external backends
+  useEffect(() => {
+    api.data.wakeup();
+  });
 
   /**
    * Handle login button click. Redirect user to auth gw login request route.


### PR DESCRIPTION
- add a wake-signal emitter to the login page:
    - sends an empty non-blocking request to `testbed-api/wake-up`