### PR TITLE
build: use infra as cicd auth

### DIFF
--- a/.github/workflows/deployment.yml
+++ b/.github/workflows/deployment.yml
@@ -22,6 +22,9 @@ jobs:
     name: Deployment
     runs-on: ubuntu-latest
     needs: build-and-test
+    permissions:
+      id-token: write
+      contents: read
     steps:
       - uses: actions/checkout@v3
       - name: Download the built artifact
@@ -33,18 +36,18 @@ jobs:
         run: |
           ls -R build
       - name: Configure AWS credentials
-        uses: aws-actions/configure-aws-credentials@v1
+        uses: Virtual-Finland-Development/infrastructure/.github/actions/configure-aws-credentials@main
         with:
-          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
-          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
-          aws-region: ${{ env.aws_region }}
+          environment: ${{ inputs.deployment_stage }}
+          aws-region: ${{ secrets.AWS_REGION }}
+          pulumi-access-token: ${{ secrets.PULUMI_ACCESS_TOKEN }}
       - name: Pulumi install, test
         working-directory: ./infra
         run: |
           npm install
           npm test
       - name: Deploy with Pulumi
-        uses: pulumi/actions@v3
+        uses: pulumi/actions@v4
         with:
           work-dir: ./infra
           command: up


### PR DESCRIPTION
- https://github.com/Virtual-Finland-Development/infrastructure/pull/12
- https://github.com/Virtual-Finland-Development/infrastructure/pull/13
- pulumi actions, version upgrade
- ennen asennusta/deplausta voisi poistella repo-salaisuudet github-repositoryn salaisuus-asetuksista